### PR TITLE
Removed conflicting config.h generation, fix on material names genera…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ set(MATERIAL_COLLECTIONS
 	winter
 )
 
-configure_file(config.h.cmake.in config.h)
+# Conflict with config.h from So${Gui} not really useful
+# configure_file(config.h.cmake.in config.h)
 configure_file(materials/materials.h.in materials/materials.h)
 
 foreach(_style ${MATERIAL_COLLECTIONS})
@@ -26,15 +27,14 @@ foreach(_style ${MATERIAL_COLLECTIONS})
 	foreach(COIN_INPUT_FILE_NAME ${MATERIAL_COLLECTION_FILES})
 		get_filename_component(_number "${COIN_INPUT_FILE_NAME}" EXT)
 		string(SUBSTRING ${_number} 1 -1 _number)
-		string(REGEX MATCH "^[0-9]+$" _is_number ${_number})
-		if(_is_number)
+		if(${_number} MATCHES "^[0-9]+$")
 			string(TOUPPER "SO${GUI}_${_style}${_number}_IV_H" COIN_HEADER_DEF)
 			set(COIN_TEXTVAR_NAME ${_style}${_number}_iv)
 			file(READ "${COIN_INPUT_FILE_NAME}" f0)
 			string(REGEX REPLACE "\\\\" "\\\\\\\\" f1 "${f0}")
 			string(REGEX REPLACE "\"" "\\\\\"" f2 "${f1}")
 			string(REGEX REPLACE "\r?\n" "\\\\n\"\n  \"" COIN_STR_SOURCE_CODE "${f2}")
-			set(FLGENPATH "materials/${_style}/${_style}${_number}.h")
+			set(FLGENPATH "materials/${_style}/${_style}_${_number}.h")
 			configure_file(strfytemplate.cmake.in ${FLGENPATH})
 		endif()
 	endforeach()


### PR DESCRIPTION
…ted files.
Hello,
several issues with data.
config.h overwrite config.h from So${Gui} I think is not useful and I removed generation.
Material s' files name were wrong, check has been fixed.
This pull request is requested for fixing compilation on gui binding that support material list.